### PR TITLE
Jenkins build and release pipelines - initial step

### DIFF
--- a/etc/jenkins/build_asm.groovy
+++ b/etc/jenkins/build_asm.groovy
@@ -1,0 +1,62 @@
+// Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Distribution License v. 1.0, which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+// or the Eclipse Distribution License v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+//  SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+// Job input parameters:
+//   GIT_BRANCH_RELEASE   - Branch to release
+
+// Job internal argumets:
+//   GIT_USER_NAME       - Git user name (for commits)
+//   GIT_USER_EMAIL      - Git user e-mail (for commits)
+//   SSH_CREDENTIALS_ID  - Jenkins ID of SSH credentials
+//   GPG_CREDENTIALS_ID  - Jenkins ID of GPG credentials (stored as KEYRING variable)
+
+pipeline {
+
+    agent any
+
+    tools {
+        jdk 'adoptopenjdk-hotspot-jdk11-latest'
+        maven 'apache-maven-latest'
+    }
+
+    environment {
+        ASM_DIR="${WORKSPACE}/org.eclipse.persistence.asm"
+    }
+
+    stages {
+        // Initialize build environment
+        stage('Init') {
+            steps {
+                git branch: GIT_BRANCH_RELEASE, credentialsId: SSH_CREDENTIALS_ID, url: GIT_REPOSITORY_URL
+                withCredentials([file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING')]) {
+                    sh label: '', script: '''
+                        gpg --batch --import "${KEYRING}"
+                        for fpr in $(gpg --list-keys --with-colons  | awk -F: \'/fpr:/ {print $10}\' | sort -u);
+                        do
+                            echo -e "5\\ny\\n" |  gpg --batch --command-fd 0 --expert --edit-key $fpr trust;
+                        done'''
+                }
+                // Git configuration
+                sh '''
+                    git config --global user.name "${GIT_USER_NAME}"
+                    git config --global user.email "${GIT_USER_EMAIL}"
+                '''
+            }
+        }
+        // Perform release
+        stage('Build') {
+            steps {
+                sh '''
+                    etc/jenkins/build_asm.sh
+                '''
+            }
+        }
+    }
+}

--- a/etc/jenkins/build_asm.sh
+++ b/etc/jenkins/build_asm.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0,
+# or the Eclipse Distribution License v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+echo '-[ EclipseLink ASM Build ]------------------------------------------------'
+(cd ${ASM_DIR} && \
+  mvn -V -B clean install -Poss-release)

--- a/etc/jenkins/includes/maven.incl.sh
+++ b/etc/jenkins/includes/maven.incl.sh
@@ -1,0 +1,97 @@
+#  Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Eclipse Public License v. 2.0 which is available at
+#  http://www.eclipse.org/legal/epl-2.0,
+#  or the Eclipse Distribution License v. 1.0 which is available at
+#  http://www.eclipse.org/org/documents/edl-v10.php.
+#
+#  SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+# Maven plugins
+VERSIONS_PLUGIN='org.codehaus.mojo:versions-maven-plugin:2.7'
+HELP_PLUGIN='org.apache.maven.plugins:maven-help-plugin:3.2.0'
+
+# Compute version strings for next development cycle.
+# Version strings are set as new shell variables with provided prefix.
+# Arguments:
+#  $1 - Variable prefix
+#  $2 - Source version
+# Variables set:
+#  "${1}_NEXT_VERSION"  - Next version string: Source string with last component increased by 1
+#  "${1}_NEXT_SNAPSHOT" - Next snapshot string: Next version string with '-SNAPSHOT' suffix
+next_version() {
+  set -f
+  local NEXT_COMPONENTS=(${2//\./ })
+  local LAST_INDEX=$((${#NEXT_COMPONENTS[@]} - 1))
+  local NEXT_COMPONENTS[${LAST_INDEX}]=$((${NEXT_COMPONENTS[${LAST_INDEX}]} + 1))
+  local COMPONENTS_STR="${NEXT_COMPONENTS[@]}"
+  local NEXT_VERSION="${COMPONENTS_STR// /.}"
+  local NEXT_SNAPSHOT="${NEXT_VERSION}-SNAPSHOT"
+  echo "${1} Next Version:    ${NEXT_VERSION}"
+  echo "${1} Next Snapshot:   ${NEXT_SNAPSHOT}"
+  eval "${1}_NEXT_VERSION"="${NEXT_VERSION}"
+  eval "${1}_NEXT_SNAPSHOT"="${NEXT_SNAPSHOT}"
+}
+
+# Prepare release version string and next development cycle versions.
+# Version strings are set as new shell variables with provided prefix.
+# Arguments:
+#  $1 - Variable prefix
+#  $2 - Build directory
+# Source variables:
+#  "${1}_VERSION" - Release version override (optional)
+# Variables set:
+#  "${1}_RELEASE_VERSION" - Release version
+read_version() {
+  local VERSION_VAR="${1}_VERSION"
+  local SNAPSHOT_VERSION=`(cd ${2} && mvn -B ${HELP_PLUGIN}:evaluate -Dexpression=project.version 2> /dev/null | grep -E '^[0-9]+(\.[0-9]+)+-SNAPSHOT$')`
+  if [ -z "${!VERSION_VAR}" ]; then
+    local RELEASE_VERSION="${SNAPSHOT_VERSION/-SNAPSHOT/}"
+  else
+    local RELEASE_VERSION="${!VERSION_VAR}"
+  fi
+  echo "${1} Release Version: ${RELEASE_VERSION}"
+  eval "${1}_RELEASE_VERSION"="${RELEASE_VERSION}"
+  next_version "${1}" "${RELEASE_VERSION}"
+}
+
+# Read Maven identifier (groupId and artifactId).
+# Maven identifier is set as new shell variables with provided prefix.
+# Arguments:
+#  $1 - Variable prefix
+#  $2 - Build directory
+# Variables set:
+#  "${1}_GROUP_ID" - Maven groupId
+#  "${1}_ARTIFACT_ID" - Maven artifactId
+read_mvn_id() {
+  local GROUP_ID=`(cd ${2} && mvn -B ${HELP_PLUGIN}:evaluate -Dexpression=project.groupId | grep -Ev '(^\[)')`
+  local ARTIFACT_ID=`(cd ${2} && mvn -B ${HELP_PLUGIN}:evaluate -Dexpression=project.artifactId | grep -Ev '(^\[)')`
+  echo "${1} Group ID:    ${GROUP_ID}"
+  echo "${1} Artifact ID: ${ARTIFACT_ID}"
+  eval "${1}_GROUP_ID"="${GROUP_ID}"
+  eval "${1}_ARTIFACT_ID"="${ARTIFACT_ID}"
+}
+
+# Set Maven artifact version.
+# Arguments:
+#  $1 - Artifact identifier (e.g. 'SPEC', 'API', 'RI')
+#  $2 - Build directory
+#  $3 - Version to set
+#  $4 - Group ID
+#  $5 - Artifact ID
+#  $6 - Additional Maven arguments
+set_version() {
+  echo '--[ Set version ]---------------------------------------------------------------'
+  # Set release version
+  (cd ${2} && \
+    mvn -U -C \
+        ${6} \
+        -DnewVersion="${3}" \
+        -DgenerateBackupPoms=false \
+        clean ${VERSIONS_PLUGIN}:set)
+  echo '--[ Commit modified pom.xml files ]---------------------------------------------'
+  local POM_FILES=`git status | grep -E 'modified:.*pom.*\.xml' | sed -e 's/[[:space:]][[:space:]]*modified:[[:space:]][[:space:]]*//'`
+  git add ${POM_FILES} && \
+  git commit -s -m "Update ${1} version of ${4}:${5} to ${3}"
+}

--- a/etc/jenkins/includes/nexus.incl.sh
+++ b/etc/jenkins/includes/nexus.incl.sh
@@ -1,0 +1,24 @@
+#  Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Eclipse Public License v. 2.0 which is available at
+#  http://www.eclipse.org/legal/epl-2.0,
+#  or the Eclipse Distribution License v. 1.0 which is available at
+#  http://www.eclipse.org/org/documents/edl-v10.php.
+#
+#  SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+# Drop old artifacts from staging repository
+# Arguments:
+#  $1 - Staging key value with grep REGEX prefixes
+#  $2 - Build directory
+drop_artifacts() {
+  echo '-[ Drop old staging repository deployments ]------------------------------------'
+  for staging_key in `(cd ${2} && mvn -B nexus-staging:rc-list | egrep "^\[INFO\] [A-Z,a-z,-]+-[0-9]+\s+[A-Z]+\s+${1}" | awk '{print $2}')`; do
+    echo "Repository ID: ${staging_key}"
+    (cd ${2} && \
+      mvn -U -C \
+          -DstagingRepositoryId="${staging_key}" \
+          nexus-staging:rc-drop)
+  done
+}

--- a/etc/jenkins/release_asm.groovy
+++ b/etc/jenkins/release_asm.groovy
@@ -1,0 +1,152 @@
+// Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Distribution License v. 1.0, which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+// or the Eclipse Distribution License v. 1.0 which is available at
+// http://www.eclipse.org/org/documents/edl-v10.php.
+//
+//  SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+// Job input parameters:
+//   ASM_VERSION       - EclipseLink ASM version to release
+//   NEXT_ASM_VERSION  - Next EclipseLink ASM snapshot version to set (e.g. 1.2.4-SNAPSHOT)
+//   BRANCH            - Branch to release
+//   DRY_RUN           - Do not publish artifacts to OSSRH and code changes to GitHub
+//   OVERWRITE_GIT     - Allows to overwrite existing version in git
+//   OVERWRITE_STAGING - Allows to overwrite existing version in OSSRH (Jakarta) staging repositories
+
+// Job internal arguments:
+//   GIT_USER_NAME       - Git user name (for commits)
+//   GIT_USER_EMAIL      - Git user e-mail (for commits)
+//   GIT_BRANCH_RELEASE  - Git branch to release
+//   SSH_CREDENTIALS_ID  - Jenkins ID of SSH credentials
+//   GPG_CREDENTIALS_ID  - Jenkins ID of GPG credentials (stored as KEYRING variable)
+
+pipeline {
+
+    agent {
+        kubernetes {
+            label 'el-master-agent-pod'
+            yaml """
+apiVersion: v1
+kind: Pod
+spec:
+
+  volumes:
+  - name: tools
+    persistentVolumeClaim:
+      claimName: tools-claim-jiro-eclipselink
+  - name: volume-known-hosts
+    configMap:
+      name: known-hosts      
+  - name: settings-xml
+    secret:
+      secretName: m2-secret-dir
+      items:
+      - key: settings.xml
+        path: settings.xml
+  - name: toolchains-xml
+    configMap:
+      name: m2-dir
+      items:
+      - key: toolchains.xml
+        path: toolchains.xml
+  - name: settings-security-xml
+    secret:
+      secretName: m2-secret-dir
+      items:
+      - key: settings-security.xml
+        path: settings-security.xml
+  - name: m2-repo
+    emptyDir: {}
+    
+  containers:
+  - name: jnlp
+    resources:
+      limits:
+        memory: "1Gi"
+        cpu: "1"
+      requests:
+        memory: "1Gi"
+        cpu: "500m"
+  - name: el-build
+    resources:
+      limits:
+        memory: "2Gi"
+        cpu: "2"
+      requests:
+        memory: "2Gi"
+        cpu: "1.5"
+    image: tkraus/el-build:1.1.9
+    volumeMounts:
+    - name: tools
+      mountPath: /opt/tools
+    - name: volume-known-hosts
+      mountPath: /home/jenkins/.ssh      
+    - name: settings-xml
+      mountPath: /home/jenkins/.m2/settings.xml
+      subPath: settings.xml
+      readOnly: true
+    - name: toolchains-xml
+      mountPath: /home/jenkins/.m2/toolchains.xml
+      subPath: toolchains.xml
+      readOnly: true
+    - name: settings-security-xml
+      mountPath: /home/jenkins/.m2/settings-security.xml
+      subPath: settings-security.xml
+      readOnly: true
+    - name: m2-repo
+      mountPath: /home/jenkins/.m2/repository
+    tty: true
+    command:
+    - cat
+"""
+        }
+    }
+
+    tools {
+        jdk 'adoptopenjdk-hotspot-jdk11-latest'
+        maven 'apache-maven-latest'
+    }
+
+    environment {
+        ASM_DIR="${WORKSPACE}/org.eclipse.persistence.asm"
+    }
+
+    stages {
+        // Initialize build environment
+        stage('Init') {
+            steps {
+                container('el-build') {
+                    git branch: GIT_BRANCH_RELEASE, credentialsId: SSH_CREDENTIALS_ID, url: GIT_REPOSITORY_URL
+                    withCredentials([file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING')]) {
+                        sh label: '', script: '''
+                            gpg --batch --import "${KEYRING}"
+                            for fpr in $(gpg --list-keys --with-colons  | awk -F: \'/fpr:/ {print $10}\' | sort -u);
+                            do
+                                echo -e "5\\ny\\n" |  gpg --batch --command-fd 0 --expert --edit-key $fpr trust;
+                            done'''
+                    }
+                    // Git configuration
+                    sh '''
+                    git config --global user.name "${GIT_USER_NAME}"
+                    git config --global user.email "${GIT_USER_EMAIL}"
+                '''
+                }
+            }
+        }
+        // Perform release
+        stage('Build and release EclipseLink ASM') {
+            steps {
+                container('el-build') {
+                    git branch: GIT_BRANCH_RELEASE, credentialsId: SSH_CREDENTIALS_ID, url: GIT_REPOSITORY_URL
+                    sh '''
+                        etc/jenkins/release_asm.sh "${ASM_VERSION}" "${NEXT_ASM_VERSION}" "${DRY_RUN}" "${OVERWRITE_GIT}" "${OVERWRITE_STAGING}"
+                    '''
+                }
+            }
+        }
+    }
+
+}

--- a/etc/jenkins/release_asm.sh
+++ b/etc/jenkins/release_asm.sh
@@ -1,0 +1,117 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0,
+# or the Eclipse Distribution License v. 1.0 which is available at
+# http://www.eclipse.org/org/documents/edl-v10.php.
+#
+# SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+#
+
+#
+# Arguments:
+# $1 -  ASM_VERSION                 - Version to release
+# $2 -  NEXT_ASM_VERSION            - Next snapshot version to set (e.g. 3.0.1-SNAPSHOT).
+# $3 -  DRY_RUN                     - Do not publish artifacts to OSSRH and code changes to GitHub.
+# $4 -  OVERWRITE_GIT               - Allows to overwrite existing version in git
+# $5 -  OVERWRITE_STAGING           - Allows to overwrite existing version in OSSRH (Jakarta) staging repositories
+
+
+ASM_VERSION="${1}"
+NEXT_ASM_VERSION="${2}"
+DRY_RUN="${3}"
+OVERWRITE_GIT="${4}"
+OVERWRITE_STAGING="${5}"
+
+
+export MAVEN_SKIP_RC="true"
+
+. etc/jenkins/includes/maven.incl.sh
+. etc/jenkins/includes/nexus.incl.sh
+
+read_version 'ASM' "${ASM_DIR}"
+
+if [ -z "${ASM_RELEASE_VERSION}" ]; then
+  echo '-[ Missing required EclipseLink ASM release version number! ]--------------------------------'
+  exit 1
+fi
+
+RELEASE_TAG="${ASM_RELEASE_VERSION}"
+RELEASE_BRANCH="${ASM_RELEASE_VERSION}-RELEASE"
+
+if [ ${DRY_RUN} = 'true' ]; then
+  echo '-[ Dry run turned on ]----------------------------------------------------------'
+  MVN_DEPLOY_ARGS='install'
+  echo '-[ Skipping GitHub branch and tag checks ]--------------------------------------'
+else
+  MVN_DEPLOY_ARGS='deploy'
+  GIT_ORIGIN=`git remote`
+  echo '-[ Prepare branch ]-------------------------------------------------------------'
+  if [[ -n `git branch -r | grep "${GIT_ORIGIN}/${RELEASE_BRANCH}"` ]]; then
+    if [ "${OVERWRITE_GIT}" = 'true' ]; then
+      echo "${GIT_ORIGIN}/${RELEASE_BRANCH} branch already exists, deleting"
+      git push --delete origin "${RELEASE_BRANCH}" && true
+    else
+      echo "Error: ${GIT_ORIGIN}/${RELEASE_BRANCH} branch already exists"
+      exit 1
+    fi
+  fi
+  echo '-[ Release tag cleanup ]--------------------------------------------------------'
+  if [[ -n `git ls-remote --tags ${GIT_ORIGIN} | grep "${RELEASE_TAG}"` ]]; then
+    if [ "${OVERWRITE_GIT}" = 'true' ]; then
+      echo "${RELEASE_TAG} tag already exists, deleting"
+      git push --delete origin "${RELEASE_TAG}" && true
+    else
+      echo "Error: ${RELEASE_TAG} tag already exists"
+      exit 1
+    fi
+  fi
+fi
+
+# Always delete local branch if exists
+git branch --delete "${RELEASE_BRANCH}" && true
+git checkout -b ${RELEASE_BRANCH}
+
+# Always delete local tag if exists
+git tag --delete "${RELEASE_TAG}" && true
+
+# Read Maven identifiers
+read_mvn_id 'ASM' "${ASM_DIR}"
+
+# Set Nexus identifiers
+ASM_STAGING_DESC="${ASM_GROUP_ID}:${ASM_ARTIFACT_ID}:${ASM_RELEASE_VERSION}"
+ASM_STAGING_KEY=$(echo ${ASM_STAGING_DESC} | sed -e 's/\./\\\./g')
+
+# Set release versions
+echo '-[ EclipseLink ASM release version ]--------------------------------------------------------'
+set_version 'ASM' "${ASM_DIR}" "${ASM_RELEASE_VERSION}" "${ASM_GROUP_ID}" "${ASM_ARTIFACT_ID}" ''
+
+if [ "${OVERWRITE_STAGING}" = 'true' ]; then
+  drop_artifacts "${ECLIPSELINK_STAGING_KEY}" "${ECLIPSELINK_DIR}"
+fi
+
+echo '-[ Deploy artifacts to staging repository ]-----------------------------'
+# Verify, sign and deploy release
+(cd ${ASM_DIR} && \
+  mvn --no-transfer-progress -U -C -B -V \
+      -Poss-release,staging -DskipTests \
+      -DstagingDescription="${ASM_STAGING_DESC}" \
+      clean ${MVN_DEPLOY_ARGS})
+
+echo '-[ Tag release ]----------------------------------------------------------------'
+git tag "${RELEASE_TAG}" -m "EclipseLink ASM ${ASM_RELEASE_VERSION} release"
+
+# Set next release cycle snapshot version
+echo '-[ EclipseLink ASM next snapshot version ]--------------------------------------------------'
+set_version 'ASM' "${ASM_DIR}" "${ASM_NEXT_SNAPSHOT}" "${ASM_GROUP_ID}" "${ASM_ARTIFACT_ID}" ''
+
+if [ ${DRY_RUN} = 'true' ]; then
+  echo '-[ Skipping GitHub update ]-----------------------------------------------------'
+else
+  echo '-[ Push branch and tag to GitHub ]----------------------------------------------'
+  git push origin "${RELEASE_BRANCH}"
+  git push origin "${RELEASE_TAG}"
+fi


### PR DESCRIPTION
This PR contains Jenkins pipelines required by build and promotion jobs see:
https://ci.eclipse.org/eclipselink/job/asm-build/
https://ci.eclipse.org/eclipselink/job/asm-promote/
This is initial version which just transfer pipeline (Groovy, shell) scripts to the new repository.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>