### PR TITLE
Add EclipseLinkClassVisitor/EclipseLinkMethodVisitor which is updated…

### DIFF
--- a/org.eclipse.persistence.asm/src/main/java/org/eclipse/persistence/internal/libraries/asm/EclipseLinkAnnotationVisitor.java
+++ b/org.eclipse.persistence.asm/src/main/java/org/eclipse/persistence/internal/libraries/asm/EclipseLinkAnnotationVisitor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021 Oracle, IBM Corporation, and/or their affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+// Contributors:
+//      IBM - initial API and implementation
+
+package org.eclipse.persistence.internal.libraries.asm;
+
+public class EclipseLinkAnnotationVisitor  extends AnnotationVisitor {
+	public EclipseLinkAnnotationVisitor() {
+		super(Opcodes.ASM9);
+	}
+	
+	public EclipseLinkAnnotationVisitor(AnnotationVisitor annotationVisitor) {
+		super(Opcodes.ASM9, annotationVisitor);
+	}
+
+}

--- a/org.eclipse.persistence.asm/src/main/java/org/eclipse/persistence/internal/libraries/asm/EclipseLinkClassVisitor.java
+++ b/org.eclipse.persistence.asm/src/main/java/org/eclipse/persistence/internal/libraries/asm/EclipseLinkClassVisitor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Oracle, IBM Corporation, and/or their affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+// Contributors:
+//      IBM - initial API and implementation
+
+package org.eclipse.persistence.internal.libraries.asm;
+
+public class EclipseLinkClassVisitor extends ClassVisitor {
+	public EclipseLinkClassVisitor() {
+		super(Opcodes.ASM9);
+	}
+	
+	public EclipseLinkClassVisitor(ClassVisitor classVisitor) {
+		super(Opcodes.ASM9, classVisitor);
+	}
+	
+	public void visit(
+			final int access,
+			final String name,
+			final String signature,
+			final String superName,
+			final String[] interfaces) {
+		visit(Opcodes.ASM9, access, name, signature, superName, interfaces);
+
+	}
+}

--- a/org.eclipse.persistence.asm/src/main/java/org/eclipse/persistence/internal/libraries/asm/EclipseLinkMethodVisitor.java
+++ b/org.eclipse.persistence.asm/src/main/java/org/eclipse/persistence/internal/libraries/asm/EclipseLinkMethodVisitor.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021 Oracle, IBM Corporation, and/or their affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+// Contributors:
+//      IBM - initial API and implementation
+
+package org.eclipse.persistence.internal.libraries.asm;
+
+public class EclipseLinkMethodVisitor extends MethodVisitor {
+	public EclipseLinkMethodVisitor() {
+		super(Opcodes.ASM9);
+	}
+	
+	public EclipseLinkMethodVisitor(MethodVisitor methodVisitor) {
+		super(Opcodes.ASM9, methodVisitor);
+	}
+}


### PR DESCRIPTION
PR for #4 , which adds EclipseLinkClassVisitor and EclipseLinkMethodVisitor, which contains additional constructors to be used by Eclipselink's ClassWeaver.java, MethodWeaver.java, and MetadataAsmFactory.java types.  These new visitor classes must be updated to use the newer ASM* Opcode constant whenever that is incremented.