### PR TITLE
[master] Jenkins release job fix

### DIFF
--- a/etc/jenkins/release.groovy
+++ b/etc/jenkins/release.groovy
@@ -139,11 +139,13 @@ spec:
         // Perform release
         stage('Build and release EclipseLink ASM') {
             steps {
-                container('el-build') {
-                    git branch: GIT_BRANCH_RELEASE, credentialsId: SSH_CREDENTIALS_ID, url: GIT_REPOSITORY_URL
-                    sh '''
+                git branch: GIT_BRANCH_RELEASE, credentialsId: SSH_CREDENTIALS_ID, url: GIT_REPOSITORY_URL
+                sshagent([SSH_CREDENTIALS_ID]) {
+                    container('el-build') {
+                        sh '''
                         etc/jenkins/release.sh "${ASM_VERSION}" "${NEXT_ASM_VERSION}" "${DRY_RUN}" "${OVERWRITE_GIT}" "${OVERWRITE_STAGING}"
                     '''
+                    }
                 }
             }
         }


### PR DESCRIPTION
This is fix for "git push" call, which failed with "git@github.com: Permission denied (publickey)." error message. It's related with some Eclipse-CI infrastructure security settings. "release.sh" script must be called within "el-build" container and this container is wrapped by "sshagent([SSH_CREDENTIALS_ID]) {".
Opposite nesting "sshagent([SSH_CREDENTIALS_ID]) {" inside "container('el-build') {" instruction leads into error.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>