### PR TITLE
EclipseLinkASMClassWriter.getLatestOPCodeVersion was emitting an incorrect warning and picking the oldest Java bytecode version if encountering an unsupported Java version (Bugzilla #579391)

### DIFF
--- a/org.eclipse.persistence.asm/src/main/java/org/eclipse/persistence/internal/libraries/asm/EclipseLinkASMClassWriter.java
+++ b/org.eclipse.persistence.asm/src/main/java/org/eclipse/persistence/internal/libraries/asm/EclipseLinkASMClassWriter.java
@@ -15,9 +15,9 @@ package org.eclipse.persistence.internal.libraries.asm;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.SortedMap;
-import java.util.Collections;
-import java.util.TreeMap;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -29,23 +29,7 @@ public class EclipseLinkASMClassWriter extends ClassWriter {
 
     private static final Logger LOG = Logger.getLogger(EclipseLinkASMClassWriter.class.getName());
 
-    private final int version = getLatestOPCodeVersion();
-
-    private static final SortedMap<String, Integer> versionMap = Collections.unmodifiableSortedMap(new TreeMap<String, Integer>() {
-        {
-            put("1.7", Opcodes.V1_7);
-            put("1.8", Opcodes.V1_8);
-            put("9", Opcodes.V9);
-            put("10", Opcodes.V10);
-            put("11", Opcodes.V11);
-            put("12", Opcodes.V12);
-            put("13", Opcodes.V13);
-            put("14", Opcodes.V14);
-            put("15", Opcodes.V15);
-            put("16", Opcodes.V16);
-            put("17", Opcodes.V17);
-        }
-    });
+    private static final int version = getLatestOPCodeVersion();
 
     public EclipseLinkASMClassWriter() {
         this(ClassWriter.COMPUTE_FRAMES);
@@ -78,8 +62,25 @@ public class EclipseLinkASMClassWriter extends ClassWriter {
     }
 
     private static int getLatestOPCodeVersion() {
+        final LinkedHashMap<String, Integer> versionMap = new LinkedHashMap<String, Integer>();
+        versionMap.put("1.7", Opcodes.V1_7);
+        versionMap.put("1.8", Opcodes.V1_8);
+        versionMap.put("9", Opcodes.V9);
+        versionMap.put("10", Opcodes.V10);
+        versionMap.put("11", Opcodes.V11);
+        versionMap.put("12", Opcodes.V12);
+        versionMap.put("13", Opcodes.V13);
+        versionMap.put("14", Opcodes.V14);
+        versionMap.put("15", Opcodes.V15);
+        versionMap.put("16", Opcodes.V16);
+        versionMap.put("17", Opcodes.V17);
+
+        final List<String> versions = new ArrayList<String>(versionMap.keySet());
+        final String oldest = versions.get(0);
+        final String latest = versions.get(versions.size() - 1);
+
         // let's default to oldest supported Java SE version
-        String v = versionMap.firstKey();
+        String v = oldest;
         if (System.getSecurityManager() == null) {
             v = System.getProperty("java.specification.version");
         } else {
@@ -101,7 +102,6 @@ public class EclipseLinkASMClassWriter extends ClassWriter {
         Integer version = versionMap.get(v);
         if (version == null) {
             // current JDK is either too new
-            String latest = versionMap.lastKey();
             if (latest.compareTo(v) < 0) {
                 LOG.log(Level.WARNING, "Java SE ''{0}'' is not fully supported yet. Report this error to the EclipseLink open source project.", v);
                 if (LOG.isLoggable(Level.FINE)) {
@@ -110,7 +110,7 @@ public class EclipseLinkASMClassWriter extends ClassWriter {
                 version = versionMap.get(latest);
             } else {
                 // or too old
-                String key = versionMap.firstKey();
+                String key = oldest;
                 LOG.log(Level.WARNING, "Java SE ''{0}'' is too old.", v);
                 if (LOG.isLoggable(Level.FINE)) {
                     LOG.log(Level.FINE, "Generating bytecode for Java SE ''{0}''.", key);


### PR DESCRIPTION
Bugzilla: https://bugs.eclipse.org/bugs/show_bug.cgi?id=579391

**SCENARIO:**

Using Eclipselink MOXy (using latest eclipselink-asm) on Java 18

**ACTUAL RESULT:**

When using EclipseLink MOXy 2.7.8 or 2.7.10 on Java 18, the following warning is printed to stderr:

org.eclipse.persistence.internal.libraries.asm.EclipseLinkASMClassWriter getLatestOPCodeVersion
WARNING: Java SE '18' is too old.


**EXPECTED VALUE:**

It should be printing:

WARNING: Java SE '18' is not fully supported yet. Report this error to the EclipseLink open source project.


**CONSEQUENCE:**

This bug also causes EclipseLink ASM to set version to 1.7 (so presumably will generate Java 1.7 bytecode rather than Java 17 bytecode)


The code is using a TreeMap for "versionMap" but then using "lastKey()" as if TreeMap preserved insertion order (or used numerical order), rather than natural string ordering, and lastKey returns "9" since the String "9" > "17"


**DESCRIPTION OF CHANGE:**

The fix for this is to switching from TreeMap to LinkedHashMap, which preserves insertion order.

In addition to this bug, the Map construction code is pointlessly creating an anonymous class and storing the Map in the heap forever, whereas "versionMap" could be constructed within getLatestOPCodeVersion and populated with calls to .put, removing the need for that anonymous class (and saving wasted heap space as an added benefit)


Additionally, "version" could be made static so that this computation only happens once per class load (and to reduce the number of times the warning might be printed to stderr)