### PR TITLE
ASM version switch to 9.4 to be ready for JDK 20.

### DIFF
--- a/org.eclipse.persistence.asm/pom.xml
+++ b/org.eclipse.persistence.asm/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <relativePath/>
     </parent>
 
     <groupId>org.eclipse.persistence</groupId>
     <artifactId>org.eclipse.persistence.asm</artifactId>
-    <version>9.3.0-SNAPSHOT</version>
+    <version>9.4.0-SNAPSHOT</version>
 
     <name>EclipseLink ASM</name>
     <description>EclipseLink extension for Java bytecode manipulation and analysis framework</description>
@@ -85,8 +85,8 @@
         <!-- 2.6.x has Java SE 7 as min supported JDK -->
         <base.java.level>7</base.java.level>
         <upper.java.level>9</upper.java.level>
-        <!-- CQ #24052 -->
-        <asm.version>9.3</asm.version>
+        <!-- CQ #24269 -->
+        <asm.version>9.4</asm.version>
         <junit.version>4.13.2</junit.version>
     </properties>
 
@@ -348,12 +348,6 @@
                                     <replacefilter>
                                         <replacetoken><![CDATA[new ArrayList<>(1)]]></replacetoken>
                                         <replacevalue><![CDATA[new ArrayList<T>(1)]]></replacevalue>
-                                    </replacefilter>
-                                </replace>
-                                <replace file="${project.build.directory}/generated-sources/asm-src/org/eclipse/persistence/internal/libraries/asm/tree/analysis/SourceValue.java">
-                                    <replacefilter>
-                                        <replacetoken><![CDATA[new SmallSet<>()]]></replacetoken>
-                                        <replacevalue><![CDATA[new SmallSet<AbstractInsnNode>()]]></replacevalue>
                                     </replacefilter>
                                 </replace>
                             </target>

--- a/org.eclipse.persistence.asm/src/main/java/module-info.java
+++ b/org.eclipse.persistence.asm/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle, IBM Corporation, and/or their affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022 Oracle, IBM Corporation, and/or their affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -20,5 +20,4 @@ module org.eclipse.persistence.asm {
     exports org.eclipse.persistence.internal.libraries.asm.commons;
     exports org.eclipse.persistence.internal.libraries.asm.signature;
     exports org.eclipse.persistence.internal.libraries.asm.tree;
-    exports org.eclipse.persistence.internal.libraries.asm.tree.analysis;
 }


### PR DESCRIPTION
There are changes in _module-info.java_ as *analysis* directory was removed plus change in the _pom.xml_ as _SourceValue.java_ was removed too. Parent pom `org.eclipse.ee4j:project` was upgraded to 1.0.7.

Signed-off-by: Radek Felcman <radek.felcman@oracle.com>