### PR TITLE
Update to ASM 9.6 + POM and code refresh

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        java_version: [ 17 ]
+        java_version: [ 17, 21 ]
 
     steps:
       - name: Checkout for build

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -48,6 +48,7 @@ jobs:
         if: ${{ matrix.java_version }} == '17'
         run: mvn -B -V -U -C -f org.eclipse.persistence.asm/pom.xml -Plicense-check clean verify -Dgpg.skip=true
       - name: Upload license-check info
+        if: ${{ matrix.java_version }} == '17'
         uses: actions/upload-artifact@v3
         with:
           name: license-summary.txt

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -43,7 +43,10 @@ jobs:
           java-version: ${{ matrix.java_version }}
           cache: maven
       - name: Verify
-        run: mvn -B -V -U -C -f org.eclipse.persistence.asm/pom.xml -Poss-release,license-check clean verify -Dgpg.skip=true
+        run: mvn -B -V -U -C -f org.eclipse.persistence.asm/pom.xml -Poss-release clean verify -Dgpg.skip=true
+      - name: License check
+        if: ${{ matrix.java_version }} != '17'
+        run: mvn -B -V -U -C -f org.eclipse.persistence.asm/pom.xml -Plicense-check clean verify -Dgpg.skip=true
       - name: Upload license-check info
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -43,12 +43,8 @@ jobs:
           java-version: ${{ matrix.java_version }}
           cache: maven
       - name: Verify
-        run: mvn -B -V -U -C -f org.eclipse.persistence.asm/pom.xml -Poss-release clean verify -Dgpg.skip=true
-      - name: License check
-        if: ${{ matrix.java_version }} == '17'
-        run: mvn -B -V -U -C -f org.eclipse.persistence.asm/pom.xml -Plicense-check clean verify -Dgpg.skip=true
+        run: mvn -B -V -U -C -f org.eclipse.persistence.asm/pom.xml -Poss-release,license-check clean verify -Dgpg.skip=true
       - name: Upload license-check info
-        if: ${{ matrix.java_version }} == '17'
         uses: actions/upload-artifact@v3
         with:
           name: license-summary.txt

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: 'zulu'
           java-version: ${{ matrix.java_version }}
           cache: maven
       - name: Verify

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Verify
         run: mvn -B -V -U -C -f org.eclipse.persistence.asm/pom.xml -Poss-release clean verify -Dgpg.skip=true
       - name: License check
-        if: ${{ matrix.java_version }} != '17'
+        if: ${{ matrix.java_version }} == '17'
         run: mvn -B -V -U -C -f org.eclipse.persistence.asm/pom.xml -Plicense-check clean verify -Dgpg.skip=true
       - name: Upload license-check info
         uses: actions/upload-artifact@v3

--- a/org.eclipse.persistence.asm/pom.xml
+++ b/org.eclipse.persistence.asm/pom.xml
@@ -83,7 +83,7 @@
     <properties>
         <legal.doc.source>${project.basedir}/..</legal.doc.source>
         <!-- 2.6.x has Java SE 7 as min supported JDK -->
-        <base.java.level>7</base.java.level>
+        <base.java.level>8</base.java.level>
         <upper.java.level>9</upper.java.level>
         <!-- CQ #24269 -->
         <asm.version>9.6</asm.version>
@@ -204,7 +204,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/org.eclipse.persistence.asm/pom.xml
+++ b/org.eclipse.persistence.asm/pom.xml
@@ -494,7 +494,7 @@
                         <plugin>
                             <groupId>org.eclipse.dash</groupId>
                             <artifactId>license-tool-plugin</artifactId>
-                            <version>1.0.2</version>
+                            <version>1.0.3-SNAPSHOT</version>
                         </plugin>
                     </plugins>
                 </pluginManagement>

--- a/org.eclipse.persistence.asm/pom.xml
+++ b/org.eclipse.persistence.asm/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.eclipse.persistence</groupId>
     <artifactId>org.eclipse.persistence.asm</artifactId>
-    <version>9.5.0-SNAPSHOT</version>
+    <version>9.6.0-SNAPSHOT</version>
 
     <name>EclipseLink ASM</name>
     <description>EclipseLink extension for Java bytecode manipulation and analysis framework</description>
@@ -86,7 +86,7 @@
         <base.java.level>7</base.java.level>
         <upper.java.level>9</upper.java.level>
         <!-- CQ #24269 -->
-        <asm.version>9.5</asm.version>
+        <asm.version>9.6</asm.version>
         <junit.version>4.13.2</junit.version>
     </properties>
 
@@ -159,32 +159,32 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.4.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.6.0</version>
                 </plugin>
                 <plugin>
                     <groupId>com.sun.wts.tools.ant</groupId>
                     <artifactId>package-rename-task</artifactId>
-                    <version>1.5.2</version>
+                    <version>1.6.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>5.1.8</version>
+                    <version>5.1.9</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -199,17 +199,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.6.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -494,7 +494,7 @@
                         <plugin>
                             <groupId>org.eclipse.dash</groupId>
                             <artifactId>license-tool-plugin</artifactId>
-                            <version>0.0.1-SNAPSHOT</version>
+                            <version>1.0.2</version>
                         </plugin>
                     </plugins>
                 </pluginManagement>

--- a/org.eclipse.persistence.asm/src/main/java/org/eclipse/persistence/internal/libraries/asm/EclipseLinkASMClassWriter.java
+++ b/org.eclipse.persistence.asm/src/main/java/org/eclipse/persistence/internal/libraries/asm/EclipseLinkASMClassWriter.java
@@ -68,7 +68,7 @@ public class EclipseLinkASMClassWriter extends ClassWriter {
         final Map<String, Integer> versionMap = new LinkedHashMap<>();
         Pattern searchPattern = Pattern.compile("^V\\d((_\\d)?|\\d*)");
         try {
-            Class opcodesClazz = Opcodes.class;
+            Class<Opcodes> opcodesClazz = Opcodes.class;
             for (Field f : opcodesClazz.getDeclaredFields()) {
                 if (searchPattern.matcher(f.getName()).matches()) {
                     versionMap.put(f.getName().replace("V","").replace('_', '.'), f.getInt(opcodesClazz));


### PR DESCRIPTION
There is output from `org.eclipse.dash:license-tool-plugin`

```
maven/mavencentral/org.ow2.asm/asm-commons/9.6, BSD-3-Clause, approved, #10775
maven/mavencentral/org.ow2.asm/asm-tree/9.6, BSD-3-Clause, approved, #10773
maven/mavencentral/org.ow2.asm/asm/9.6, BSD-3-Clause, approved, #10776
```