### PR TITLE
[master] Maven build - Snapshots publishing change

### DIFF
--- a/etc/jenkins/publish_snapshots.sh
+++ b/etc/jenkins/publish_snapshots.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, 2025 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -18,7 +18,7 @@ else
     echo '-[ EclipseLink ASM Publish to Jakarta Snapshots ]-----------------------------------------------------------'
     cd "${ASM_DIR}"
     mvn --no-transfer-progress -U -C -B -V \
-      -Psnapshots -DskipTests \
+      -Psnapshot-build -DskipTests \
       -Ddoclint=none -Ddeploy \
       deploy
 fi

--- a/org.eclipse.persistence.asm/pom.xml
+++ b/org.eclipse.persistence.asm/pom.xml
@@ -221,6 +221,11 @@
                     <artifactId>osgiversion-maven-plugin</artifactId>
                     <version>4.0.0-M3</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.9.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -511,6 +516,27 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>snapshot-build</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                            <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Snapshots publishing target change from https://jakarta.oss.sonatype.org/content/repositories/snapshots/ into https://central.sonatype.com/repository/maven-snapshots/